### PR TITLE
Port to latest RustCrypto crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,12 @@ path = "src/utility.rs"
 
 [dependencies]
 dbus = "0.8.4"
-dbus-crossroads = "0.2.1"
 parsec-client = "0.14.1"
 ring = { version = "0.16.15", features = ["std"] }
 anyhow = "1.0.32"
-rsa = "0.5.0"
-pkcs1 = "0.2.4"
-sha2 = "0.9.1"
+rsa = "0.9"
+pkcs1 = "0.7"
+sha2 = "0.10"
 hex = "0.4.0"
 rand = "0.8"
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -3,8 +3,8 @@ static DBUS_NAME: &str = "com.github.puiterwijk.dbus_parsec";
 
 use anyhow::{ensure, Context, Result};
 
-use pkcs1::FromRsaPublicKey;
-use rsa::{PaddingScheme, PublicKey, RsaPublicKey};
+use pkcs1::DecodeRsaPublicKey;
+use rsa::{Oaep, RsaPublicKey};
 
 use rand::rngs::OsRng;
 
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
 
     // Encrypt the wrapper key
     let wrapped_wrapkey = pubkey
-        .encrypt(&mut rsarand, PaddingScheme::new_oaep::<Sha256>(), &wrapkey)
+        .encrypt(&mut rsarand, Oaep::new::<Sha256>(), &wrapkey)
         .with_context(|| "Unable to encrypt wrapper key")?;
 
     // Encrypt the secret


### PR DESCRIPTION
- pkcs1 v0.2 -> v0.7
- rsa v0.5 -> v0.9
- sha2 v0.9 -> v0.10

Additionally, the unused dependency on "dbus-crossroads" is removed.
