### PR TITLE
chore: bump ring to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/utility.rs"
 [dependencies]
 dbus = "0.8.4"
 parsec-client = "0.14.1"
-ring = { version = "0.16.15", features = ["std"] }
+ring = { version = "0.17", features = ["std"] }
 anyhow = "1.0.32"
 rsa = "0.9"
 pkcs1 = "0.7"


### PR DESCRIPTION
Version 0.17 of ring now supports all CPU architectures that are supported
by Fedora. Any workarounds for ppc64le and s390x in Fedora packages can be
dropped in packages that use ring >= 0.17 exclusively.
